### PR TITLE
new value for a space character from the timesFor method

### DIFF
--- a/Morse.sc
+++ b/Morse.sc
@@ -11,7 +11,7 @@ Morse {
 			times = code.collect({ arg code, i; 
 				[ [ dot, dash, medium ] @ code, intra ];
 			}).flat; 
-			times.putLast(short);
+			if(times[time.size-2] == stop, {times.putLast(medium)}, {times.putLast(short)});
 
 		}, { if (verbose) { ("Morse found nothing for key: " + char).inform }; [] });
 		

--- a/Morse.sc
+++ b/Morse.sc
@@ -11,7 +11,7 @@ Morse {
 			times = code.collect({ arg code, i; 
 				[ [ dot, dash, stop ] @ code, intra ];
 			}).flat; 
-			if(times[time.size-2] == stop, {times.putLast(medium)}, {times.putLast(short)});
+			if(times[times.size-2] == stop, {times.putLast(medium)}, {times.putLast(short)});
 
 		}, { if (verbose) { ("Morse found nothing for key: " + char).inform }; [] });
 		

--- a/Morse.sc
+++ b/Morse.sc
@@ -1,7 +1,7 @@
 
 Morse { 
 	classvar <>verbose = true; 
-	classvar <>dot = 0.1, <>dash = 0.3, <>intra = 0.1, <>short = 0.3, <>medium = 0.7; 
+	classvar <>stop = 0.0, <>dot = 0.1, <>dash = 0.3, <>intra = 0.1, <>short = 0.3, <>medium = 0.7; 
 	
 	*timesFor { arg char = $x; 
 		var code, times;
@@ -9,7 +9,7 @@ Morse {
 	
 		if (code.notNil, { 
 			times = code.collect({ arg code, i; 
-				[ [ dot, dash, medium ] @ code, intra ];
+				[ [ dot, dash, stop ] @ code, intra ];
 			}).flat; 
 			if(times[time.size-2] == stop, {times.putLast(medium)}, {times.putLast(short)});
 


### PR DESCRIPTION
The timesFor method currently returns an array of pairs of "on time" and "off time" values that represent the dot or dash (the "on time") and the silence between them (the "off time").  The current method returns [0.3, 0.7] for a space character (or maybe its [0.7, 0.3], I can't remember).  The revised method would return [0.0, 0.7].  I found this to be a more accurate conversion to Morse code while parsing thru a stiring, or from an external source (when receiving characters of a parsed string via OSC).  Sorry it took 3 tries to get it posted correctly.  This is my first pull request.